### PR TITLE
Update fail2ban-geo.sql

### DIFF
--- a/fail2ban-geo.sql
+++ b/fail2ban-geo.sql
@@ -27,11 +27,12 @@ DROP TABLE IF EXISTS `banned_ips`;
 
 CREATE TABLE `banned_ips` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `ip` varchar(15) DEFAULT NULL,
-  `hostname` varchar(128) DEFAULT NULL,
-  `iso` varchar(2) DEFAULT NULL,
+  `ip` varchar(39) DEFAULT NULL,
+  `hostname` varchar(64) DEFAULT NULL,
+  `iso` char(2) DEFAULT NULL,
   `date_time` datetime DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  INDEX iso ( iso)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
@@ -43,11 +44,12 @@ DROP TABLE IF EXISTS `countries`;
 
 CREATE TABLE `countries` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `lat` varchar(9) DEFAULT NULL,
-  `lng` varchar(9) DEFAULT NULL,
-  `name` varchar(64) DEFAULT NULL,
-  `iso` varchar(2) DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  `lat` varchar(9) NOT NULL,
+  `lng` varchar(9) NOT NULL,
+  `name` varchar(64) NOT NULL,
+  `iso` char(2) NOT NULL,
+  PRIMARY KEY (`id`),
+  INDEX iso ( iso )
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 LOCK TABLES `countries` WRITE;


### PR DESCRIPTION
your code seems to be looking up by iso so I've added an index here. Iso is always 2 characters.

Countries have all fields included.

For IPv6 support, IP addresses are longer hence 39.

hostnames are limited by the DNS rfc to 64 characters so I recommend using this.

Also with your php code, avoid doing select \* in the sql. Pull out the field names you're using.

Keep up the good work.
